### PR TITLE
Change how we get GeoLite2 databases from maxmind

### DIFF
--- a/recipes/update_geoip_dbs.rb
+++ b/recipes/update_geoip_dbs.rb
@@ -12,7 +12,6 @@ apt_package 'geoipupdate' do
   notifies :create, 'template[/etc/GeoIP.conf]', :immediately
 end
 
-# TODO: Figure out if the EditionIDs are all needed, or can we skip some?
 template '/etc/GeoIP.conf' do
   source 'GeoIP.conf.erb'
   variables({ directory_path: directory_path })

--- a/recipes/update_geoip_dbs.rb
+++ b/recipes/update_geoip_dbs.rb
@@ -4,20 +4,47 @@ directory directory_path do
   recursive true
 end
 
-tar_extract 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz' do
-  target_dir '/tmp'
-  compress_char 'z'
+apt_package 'geoipupdate' do
+  notifies :create, 'template[/usr/local/etc/GeoIP.conf]', :immediately
 end
 
-tar_extract 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz' do
-  target_dir '/tmp'
-  compress_char 'z'
+template '/usr/local/etc/GeoIP.conf' do
+  source 'GeoIP.conf.erb'
+  variables({
+              account_id: account_id,
+              license_key: license_key,
+              edition_ids: edition_ids,
+              directory_path: directory_path
+            })
+
+  action :nothing
+  notifies :run, 'bash[geoipupdate]', :immediately
 end
 
-bash 'copy files to where telize expects them to be' do
+bash 'geoipupdate' do
   code <<~CODE
-  cp /tmp/GeoLite2-City_*/GeoLite2-City.mmdb #{directory_path}/
-  cp /tmp/GeoLite2-ASN_*/GeoLite2-ASN.mmdb #{directory_path}/
-  chown -R telize:telize #{directory_path}
+  /usr/local/bin/geoipupdate
   CODE
+
+  action :nothing
 end
+
+# TODO: set up a cron job to run geoipupdate weekly
+
+#tar_extract 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz' do
+#  target_dir '/tmp'
+#  compress_char 'z'
+#end
+#
+#tar_extract 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz' do
+#  target_dir '/tmp'
+#  compress_char 'z'
+#end
+#
+#bash 'copy files to where telize expects them to be' do
+#  code <<~CODE
+#  cp /tmp/GeoLite2-City_*/GeoLite2-City.mmdb #{directory_path}/
+#  cp /tmp/GeoLite2-ASN_*/GeoLite2-ASN.mmdb #{directory_path}/
+#  chown -R telize:telize #{directory_path}
+#  CODE
+#end

--- a/recipes/update_geoip_dbs.rb
+++ b/recipes/update_geoip_dbs.rb
@@ -6,12 +6,17 @@ directory directory_path do
   recursive true
 end
 
-apt_package 'geoipupdate'
+# This package will install a default /etc/GeoIP.conf, so we must
+# wait until it's installed to overwrite it with our own.
+apt_package 'geoipupdate' do
+  notifies :create, 'template[/etc/GeoIP.conf]', :immediately
+end
 
 # TODO: Figure out if the EditionIDs are all needed, or can we skip some?
 template '/etc/GeoIP.conf' do
   source 'GeoIP.conf.erb'
   variables({ directory_path: directory_path })
+  action :nothing
 end
 
 cron 'run geoipupdate' do

--- a/recipes/update_geoip_dbs.rb
+++ b/recipes/update_geoip_dbs.rb
@@ -9,7 +9,7 @@ end
 apt_package 'geoipupdate'
 
 # TODO: Figure out if the EditionIDs are all needed, or can we skip some?
-template '/usr/local/etc/GeoIP.conf' do
+template '/etc/GeoIP.conf' do
   source 'GeoIP.conf.erb'
   variables({ directory_path: directory_path })
 end
@@ -19,7 +19,5 @@ cron 'run geoipupdate' do
   weekday '0'
   hour '4'
   minute '0'
-  #shell '/bin/bash'
-  #path '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
-  command '/usr/local/bin/geoipupdate'
+  command '/usr/bin/geoipupdate'
 end

--- a/templates/GeoIP.conf.erb
+++ b/templates/GeoIP.conf.erb
@@ -1,5 +1,9 @@
 AccountID ACCOUNT_ID_PLACEHOLDER
 LicenseKey LICENSE_KEY_PLACEHOLDER
-EditionIDs GeoLite2-City GeoLite2-Country
+
+# Even though we don't care about the ASN information for the purposes of what we return,
+# the telize code requires ASN and City databases, so we must include both.
+# See https://github.com/fcambus/telize#geoip2-databases
+EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country
 
 DatabaseDirectory <%= @directory_path %>

--- a/templates/GeoIP.conf.erb
+++ b/templates/GeoIP.conf.erb
@@ -1,0 +1,5 @@
+AccountID <%= @account_id %>
+LicenseKey <%= @license_key %>
+EditionIDs <%= @edition_ids %>
+
+DatabaseDirectory <%= @directory_path %>

--- a/templates/GeoIP.conf.erb
+++ b/templates/GeoIP.conf.erb
@@ -1,5 +1,5 @@
 AccountID ACCOUNT_ID_PLACEHOLDER
 LicenseKey LICENSE_KEY_PLACEHOLDER
-EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country
+EditionIDs GeoLite2-City GeoLite2-Country
 
 DatabaseDirectory <%= @directory_path %>

--- a/templates/GeoIP.conf.erb
+++ b/templates/GeoIP.conf.erb
@@ -1,5 +1,5 @@
-AccountID <%= @account_id %>
-LicenseKey <%= @license_key %>
-EditionIDs <%= @edition_ids %>
+AccountID ACCOUNT_ID_PLACEHOLDER
+LicenseKey LICENSE_KEY_PLACEHOLDER
+EditionIDs GeoLite2-ASN GeoLite2-City GeoLite2-Country
 
 DatabaseDirectory <%= @directory_path %>


### PR DESCRIPTION
This changes how we download the GeoLite2 databases that allow us to look up IP addresses, in accordance with [changes to how we can access those databases](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/). Now, instead of downloading those during AMI building, we install and configure the `geoipupdate` tool so that we can download them on instance boot and weekly thereafter.