### PR TITLE
Use ip command instead of ifconfig

### DIFF
--- a/files/default/finish_kore_config.sh
+++ b/files/default/finish_kore_config.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 NET_IF=$(ip link | awk -F: '$0 !~ "lo|docker|tun|^[^0-9]"{print $2;getline}')
-PRIVATE_IP=$(ifconfig $NET_IF 2>/dev/null | awk '/inet / {print $2}')
+PRIVATE_IP=$(ip address show ens5 | awk '/inet / {print $2}' | awk -F/ '{ print $1}')
 
 sed -i -e "s%127.0.0.1%$PRIVATE_IP%" /srv/telize/telize.config
 

--- a/files/default/finish_kore_config.sh
+++ b/files/default/finish_kore_config.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 NET_IF=$(ip link | awk -F: '$0 !~ "lo|docker|tun|^[^0-9]"{print $2;getline}')
-PRIVATE_IP=$(ip address show ens5 | awk '/inet / {print $2}' | awk -F/ '{ print $1}')
+PRIVATE_IP=$(ip address show $NET_IF | awk '/inet / {print $2}' | awk -F/ '{ print $1}')
 
 sed -i -e "s%127.0.0.1%$PRIVATE_IP%" /srv/telize/telize.config
 

--- a/recipes/kore_server.rb
+++ b/recipes/kore_server.rb
@@ -23,9 +23,6 @@ bash 'build server' do
   cwd '/srv/telize'
 end
 
-# needed for ifconfig, which finish_core_config.sh uses
-apt_package 'net-tools'
-
 cookbook_file '/etc/finish_kore_config.sh' do
   source 'finish_kore_config.sh'
   mode '0755'

--- a/recipes/kore_server.rb
+++ b/recipes/kore_server.rb
@@ -23,6 +23,9 @@ bash 'build server' do
   cwd '/srv/telize'
 end
 
+# needed for ifconfig, which finish_core_config.sh uses
+apt_package 'net-tools'
+
 cookbook_file '/etc/finish_kore_config.sh' do
   source 'finish_kore_config.sh'
   mode '0755'


### PR DESCRIPTION
The `ifconfig` command is deprecated, and is no longer installed by default in Ubuntu 20.04. This updates our boot-time setup script to instead use the modern `ip` command for the purpose of getting the instance's private IP address.