### PR TITLE
Update kore config file to version 4 syntax

### DIFF
--- a/files/default/telize.config
+++ b/files/default/telize.config
@@ -17,10 +17,21 @@ validator v_callback regex ^.*$
 domain * {
   accesslog /srv/telize/telize.log
 
-  static    /ip                   request_ip
-  static    /jsonip               request_json_ip
-  static    /geoip                request_location
-  dynamic   ^/geoip/[a-f0-9\:.]*$ request_location
+  route /ip {
+    handler request_ip
+  }
+
+  route /jsonip {
+    handler request_json_ip
+  }
+
+  route /geoip {
+    handler request_location
+  }
+
+  route ^/geoip/[a-f0-9\:.]*$ {
+    handler request_location
+  }
 
   restrict  /ip                   get head
   restrict  /jsonip               get head

--- a/files/default/telize.config
+++ b/files/default/telize.config
@@ -10,6 +10,8 @@ privsep worker {
   runas telize
 }
 
+seccomp_tracing yes
+
 rand_file /srv/telize/dev/urandom
 
 validator v_callback regex ^.*$

--- a/files/default/telize.config
+++ b/files/default/telize.config
@@ -19,34 +19,24 @@ domain * {
 
   route /ip {
     handler request_ip
+    methods get head
   }
 
   route /jsonip {
     handler request_json_ip
+    methods get head
+    validate get callback v_callback
   }
 
   route /geoip {
     handler request_location
+    methods get head
+    validate get callback v_callback
   }
 
   route ^/geoip/[a-f0-9\:.]*$ {
     handler request_location
-  }
-
-  restrict  /ip                   get head
-  restrict  /jsonip               get head
-  restrict  /geoip                get head
-  restrict  ^/geoip/[a-f0-9\:.]*$ get head
-
-  params qs:get /jsonip {
-    validate  callback  v_callback
-  }
-
-  params qs:get /geoip {
-    validate  callback  v_callback
-  }
-
-  params qs:get ^/geoip/[a-f0-9\:.]*$ {
-    validate  callback  v_callback
+    methods get head
+    validate get callback v_callback
   }
 }

--- a/files/default/telize.config
+++ b/files/default/telize.config
@@ -5,8 +5,10 @@ server notls {
 
 load ./telize.so telize_init
 
-root /srv/telize
-runas telize
+privsep worker {
+  root /srv/telize
+  runas telize
+}
 
 rand_file /srv/telize/dev/urandom
 

--- a/files/default/telize.config
+++ b/files/default/telize.config
@@ -15,6 +15,8 @@ rand_file /srv/telize/dev/urandom
 validator v_callback regex ^.*$
 
 domain * {
+  attach notls
+
   accesslog /srv/telize/telize.log
 
   route /ip {


### PR DESCRIPTION
Since we updated to the latest version 4.2.2 of Kore server, we need to update the config file to the corresponding syntax.

I've tested this on staging and it works. (The AMI on staging now is built from this version.)